### PR TITLE
[fix] Fix integer overflow in Correct.compareTo()

### DIFF
--- a/src/test/java/org/artrev/compareverifier/implementations/Correct.java
+++ b/src/test/java/org/artrev/compareverifier/implementations/Correct.java
@@ -42,7 +42,7 @@ public class Correct implements Comparable<Correct> {
 
     @Override
     public int compareTo(final Correct other) {
-        return value - other.value;
+        return Integer.compare(value, other.value);
     }
 
     @Override


### PR DESCRIPTION
Subtraction-based comparison (value - other.value) overflows for extreme int values e.g. Integer.MIN_VALUE compared to a positive number. Replace with Integer.compare() which is overflow-safe.